### PR TITLE
feat: cdpilot dismiss — heuristic auto-click for LLM sign-in walls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to cdpilot will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`cdpilot dismiss [N|aggressive]`** — heuristic auto-click for "Stay signed out / No thanks / Continue without account" buttons. Designed for unauthenticated queries against LLM chat sites (ChatGPT, Perplexity, Claude.ai, Gemini) that gate access behind a sign-up modal but offer an escape hatch. Built-in pattern library covers English + Turkish dismissive phrases with weighted scoring (exact-match bonus). **Safety guards** are load-bearing: an explicit negative-pattern list ("delete account", "sign out", "subscribe", Turkish equivalents) disqualifies dangerous lookalikes — one negative hit on any of the element's text/aria/title/value attributes and it's out, regardless of how many positive patterns also match. Visibility gate (0-size, display:none, visibility:hidden, opacity<0.1) and a minimum score threshold of 40 prevent weak-match misfires. Pass an integer N (1-10) or `aggressive` (up to 5) to handle chained modals — common on cookie-banner-then-signup pages. MCP: `browser_dismiss`.
+
 ### Breaking
 - **Visual feedback default flipped to OFF.** The glow border, fake cursor, click ripples and keystroke display were originally a trust signal that made an automation session legible to a human watching the screen. In day-to-day automation use the animations made cdpilot feel slow and amateurish — animated cursor moves take frames, the glow re-flashes between pages, every action triggers a ripple. Default OFF gives a quiet, professional experience. Bring it back any of these ways: `cdpilot show on` (persists), `CDPILOT_SHOW=1` (one-shot), or `CDPILOT_MCP_SESSION=1` (the existing MCP persistent-glow flow, still honored exactly as before). The MCP server itself sets `CDPILOT_MCP_SESSION=1` so AI sessions retain the visible glow automatically — no migration needed for that flow.
 

--- a/bin/cdpilot.js
+++ b/bin/cdpilot.js
@@ -328,6 +328,13 @@ function showHelp() {
     show [on|off]      Visual feedback (glow + cursor + ripples).
                        Default OFF since 0.4.4 — opt-in for "see automation" mode.
 
+  SMART NAVIGATION
+    dismiss [N|aggressive]
+                       Click best "Stay signed out / No thanks / Skip" button.
+                       English + Turkish patterns; never clicks destructive
+                       lookalikes (Delete account, Sign out, Subscribe).
+                       Pass N (1-10) or "aggressive" for chained modals.
+
   TABS
     tabs               List open tabs
     new-tab [url]      Open new tab

--- a/src/cdpilot.py
+++ b/src/cdpilot.py
@@ -4423,6 +4423,203 @@ async def cmd_smart_click(text):
         print(f'  Also found: {", ".join(data["alternatives"])}')
 
 
+# ─── Auto-dismiss: heuristic click for "leave me alone" modal buttons ───
+#
+# Many sites (especially LLM chat UIs — ChatGPT, Perplexity, Claude.ai, Gemini)
+# gate access behind a sign-up modal but offer an escape hatch like "Stay
+# signed out" or "Continue without". For unauthenticated query workflows
+# (citation tracking, scraping public AI answers, etc.) we need to find and
+# click that escape hatch reliably without firing on dangerous lookalikes.
+#
+# Two lists, evaluated against every visible clickable's text/aria/title:
+#   POSITIVE → contribute a positive score (higher = more dismissive)
+#   NEGATIVE → contribute a negative penalty (any hit = element is disqualified)
+#
+# Conservative on purpose: anti-patterns block obvious traps ("Delete account",
+# "Sign out"), and the minimum score threshold (40) means weak partial matches
+# don't trigger a click.
+
+DISMISS_POSITIVE = [
+    # English — direct anonymous-use intent
+    ("stay signed out", 100), ("keep me signed out", 100),
+    ("continue without signing in", 100), ("continue without an account", 100),
+    ("use without an account", 95), ("continue as guest", 95),
+    ("stay logged out", 95), ("no, thanks", 90),
+    # English — generic dismiss
+    ("no thanks", 85), ("not now", 80), ("maybe later", 75),
+    ("skip for now", 75), ("skip", 65), ("dismiss", 70),
+    ("later", 55), ("close", 50),
+    # Cookie / GDPR — these unblock the page without consenting away rights
+    ("reject all", 60), ("only necessary", 60), ("only essential", 60),
+    ("decline", 55),
+    # Turkish
+    ("şimdi değil", 80), ("şimdilik geç", 80), ("üye olmadan", 95),
+    ("hesapsız devam et", 95), ("girişsiz", 90), ("kapat", 50),
+    ("atla", 65), ("vazgeç", 55), ("yok teşekkürler", 85),
+    ("reddet", 55), ("tümünü reddet", 60),
+]
+
+DISMISS_NEGATIVE = [
+    # Account destruction — never auto-click these
+    "delete account", "remove account", "deactivate account",
+    "hesabı sil", "hesabımı sil", "hesabı kapat",
+    # Session destruction — opposite of what we want
+    "sign out", "log out", "logout", "çıkış yap", "oturumu kapat",
+    # Destructive confirmations
+    "yes, delete", "confirm delete", "permanently delete",
+    "evet, sil", "kalıcı olarak sil",
+    # Subscription / payment
+    "subscribe", "upgrade", "buy now", "satın al", "abone ol",
+]
+
+
+def _dismiss_js_template():
+    """Build the JS expression for cmd_dismiss. Inlines pattern lists as JSON.
+
+    Pulled out into a helper so tests can grep for the patterns without
+    paying for a 200-line literal string in every function definition.
+    """
+    return f"""
+    (function() {{
+      var POS = {json.dumps(DISMISS_POSITIVE)};
+      var NEG = {json.dumps(DISMISS_NEGATIVE)};
+      var MIN_SCORE = 40;
+
+      function checkText(t) {{
+        if (!t) return {{ pos: 0, neg: false, hit: '' }};
+        var s = (t + '').toLowerCase().trim();
+        // Disqualifier first — one negative hit and the element is out,
+        // regardless of how many positive patterns also match.
+        for (var i = 0; i < NEG.length; i++) {{
+          if (s.indexOf(NEG[i]) !== -1) return {{ pos: 0, neg: true, hit: NEG[i] }};
+        }}
+        var bestPos = 0, bestHit = '';
+        for (var j = 0; j < POS.length; j++) {{
+          var pat = POS[j][0], weight = POS[j][1];
+          if (s.indexOf(pat) !== -1) {{
+            // Exact match bonus; otherwise scaled by how much of the
+            // element's text matches the pattern (longer match = more
+            // confident).
+            var score = (s === pat) ? weight + 10 : weight;
+            if (score > bestPos) {{ bestPos = score; bestHit = pat; }}
+          }}
+        }}
+        return {{ pos: bestPos, neg: false, hit: bestHit }};
+      }}
+
+      var els = document.querySelectorAll(
+        'a, button, input[type=submit], input[type=button], ' +
+        '[role=button], [role=link], [role=menuitem], [role=option], ' +
+        'summary, [onclick], [tabindex]'
+      );
+
+      var best = null;
+      Array.from(els).forEach(function(el) {{
+        // Must be visible — invisible/0-size elements are not real buttons
+        var rect = el.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) return;
+        var style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return;
+        if (parseFloat(style.opacity) < 0.1) return;
+
+        var texts = [
+          el.textContent || '',
+          el.getAttribute('aria-label') || '',
+          el.getAttribute('title') || '',
+          el.value || '',
+          el.getAttribute('alt') || ''
+        ];
+
+        var disq = false, bestPos = 0, bestHit = '';
+        for (var k = 0; k < texts.length; k++) {{
+          var r = checkText(texts[k]);
+          if (r.neg) {{ disq = true; break; }}
+          if (r.pos > bestPos) {{ bestPos = r.pos; bestHit = r.hit; }}
+        }}
+        if (disq) return;
+        if (bestPos < MIN_SCORE) return;
+
+        if (best === null || bestPos > best.score) {{
+          best = {{
+            score: bestPos,
+            hit: bestHit,
+            text: (texts[0] || texts[1] || '').trim().substring(0, 80),
+            tag: el.tagName.toLowerCase(),
+            x: rect.x + rect.width / 2,
+            y: rect.y + rect.height / 2,
+            el: el
+          }};
+        }}
+      }});
+
+      if (best === null) return JSON.stringify({{ found: false }});
+
+      best.el.scrollIntoView({{behavior:'instant', block:'center'}});
+      best.el.click();
+      return JSON.stringify({{
+        found: true,
+        tag: best.tag,
+        text: best.text,
+        pattern: best.hit,
+        score: best.score
+      }});
+    }})()
+    """
+
+
+async def cmd_dismiss(repeat=None):
+    """Find and click the strongest "dismiss / continue without account" button.
+
+    Designed for LLM chat sites that gate queries behind a sign-up modal but
+    offer an escape hatch ("Stay signed out", "No thanks", etc.). Built-in
+    pattern library covers English + Turkish dismissive phrases and explicitly
+    excludes destructive lookalikes ("Delete account", "Sign out", "Subscribe").
+
+    Usage:
+      cdpilot dismiss              # one shot — click best dismiss button if any
+      cdpilot dismiss 3            # repeat up to 3 times (chained modals)
+      cdpilot dismiss aggressive   # repeat until no candidates found (max 5)
+
+    Exit code: 0 if something was clicked or nothing to dismiss, 1 on error.
+    """
+    # Parse repeat: int N, "aggressive" (=5), or default 1
+    if repeat is None:
+        max_iter = 1
+    elif isinstance(repeat, str) and repeat.lower() == 'aggressive':
+        max_iter = 5
+    else:
+        try:
+            max_iter = max(1, min(int(repeat), 10))
+        except (TypeError, ValueError):
+            print(f"Invalid repeat: {repeat}. Use a number 1-10 or 'aggressive'.", file=sys.stderr)
+            sys.exit(1)
+
+    ws_url, _ = get_page_ws()
+    js = _dismiss_js_template()
+    total_clicked = 0
+    for i in range(max_iter):
+        r = await cdp_send(ws_url, [(1, "Runtime.evaluate", {"expression": js, "returnByValue": True})])
+        raw = r.get(1, {}).get("result", {}).get("value", "")
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            print("Error parsing dismiss result", file=sys.stderr)
+            sys.exit(1)
+        if not data.get("found"):
+            if total_clicked == 0:
+                print("No dismiss candidates on page.")
+            break
+        total_clicked += 1
+        print(f'Dismissed: {data["tag"].upper()} "{data["text"]}" '
+              f'(pattern: "{data["pattern"]}", score: {data["score"]})')
+        # Give the modal a moment to close before next scan
+        if i + 1 < max_iter:
+            await asyncio.sleep(0.4)
+
+    if total_clicked:
+        print(f'Total dismissed: {total_clicked}')
+
+
 async def cmd_smart_fill(text, value):
     """Fill input by label/placeholder text — no CSS selector needed.
 
@@ -5540,6 +5737,8 @@ class MCPServer:
              "inputSchema": {"type": "object", "properties": {}}},
             {"name": "browser_smart_click", "description": "Click an element by its visible text — no CSS selector needed. Uses fuzzy matching across text content, aria-label, title, placeholder, and value. Returns match score and alternatives. Like Stagehand act('Click login') but without LLM cost. Use when you know WHAT to click but not the exact selector.",
              "inputSchema": {"type": "object", "properties": {"text": {"type": "string", "description": "Visible text of the element to click (e.g. 'Login', 'Submit Order', 'Learn more')"}}, "required": ["text"]}},
+            {"name": "browser_dismiss", "description": "Find and click the strongest 'dismiss / continue without account' button on the page. Built-in pattern library covers English + Turkish dismissive phrases ('Stay signed out', 'No thanks', 'Skip', 'Continue without', etc.) and explicitly excludes destructive lookalikes (Delete account, Sign out, Subscribe). Designed for LLM chat sites that gate queries behind a sign-up modal. Pass 'aggressive' or an integer N (max 10) to handle chained modals.",
+             "inputSchema": {"type": "object", "properties": {"repeat": {"type": "string", "description": "Optional. Number of dismiss attempts (1-10) or 'aggressive' (up to 5 chained). Default: 1.", "default": "1"}}}},
             {"name": "browser_smart_fill", "description": "Fill an input by its label or placeholder text — no CSS selector needed. Finds input by associated label, placeholder, aria-label, name, or id. React-compatible value setting. Use when you know WHAT field to fill but not the exact selector.",
              "inputSchema": {"type": "object", "properties": {"label": {"type": "string", "description": "Label or placeholder text of the input (e.g. 'Email', 'Password', 'Search')"}, "value": {"type": "string", "description": "Value to fill in the input"}}, "required": ["label", "value"]}},
             {"name": "browser_smart_select", "description": "Select a dropdown option by label and option text — no CSS selector needed. Finds the select element by label/name, then selects the matching option. Use for dropdown interactions without knowing selectors.",
@@ -5624,6 +5823,7 @@ class MCPServer:
             "browser_extract": lambda a: ["extract", a.get("selector", "")] + ([f"--{a['format']}"] if a.get("format") and a["format"] != "text" else []),
             "browser_observe": lambda a: ["observe"],
             "browser_smart_click": lambda a: ["smart-click", a.get("text", "")],
+            "browser_dismiss": lambda a: ["dismiss"] + ([str(a["repeat"])] if a.get("repeat") else []),
             "browser_smart_fill": lambda a: ["smart-fill", a.get("label", ""), a.get("value", "")],
             "browser_smart_select": lambda a: ["smart-select", a.get("label", ""), a.get("option", "")],
             "browser_describe": lambda a: ["describe"],
@@ -5811,6 +6011,7 @@ if __name__ == "__main__":
         'observe': cmd_observe,
         'run': lambda: (require_args(1, 'run <script.cdp>'), None)[1] if not args else cmd_run_script(args[0]),
         'smart-click': lambda: (require_args(1, 'smart-click <text>'), None)[1] if not args else cmd_smart_click(" ".join(args)),
+        'dismiss': lambda: cmd_dismiss(args[0] if args else None),
         'smart-fill': lambda: (require_args(2, 'smart-fill <label> <value>'), None)[1] if len(args) < 2 else cmd_smart_fill(args[0], " ".join(args[1:])),
         'smart-select': lambda: (require_args(2, 'smart-select <label> <option>'), None)[1] if len(args) < 2 else cmd_smart_select(args[0], " ".join(args[1:])),
         'assert': lambda: (require_args(1, 'assert <selector> [text]'), None)[1] if not args else cmd_assert(args[0], args[1] if len(args) > 1 else None),

--- a/test/test.js
+++ b/test/test.js
@@ -516,6 +516,75 @@ test('help output advertises show and fast', () => {
   assert(out.includes('fast'), "Help should advertise fast");
 });
 
+// ── Auto-dismiss: pattern lib + safety guards ──
+
+test('dismiss pattern lib: positives cover LLM chat escape hatches', () => {
+  // Direct anonymous-use intent — these are the killer use cases.
+  // Score asymmetry matters: "stay signed out" must beat generic "later".
+  assert(PY_CONTENT.includes('"stay signed out", 100'),
+    "DISMISS_POSITIVE should include 'stay signed out' at weight 100");
+  assert(PY_CONTENT.includes('"continue without signing in", 100'),
+    "DISMISS_POSITIVE should include 'continue without signing in' at weight 100");
+  assert(PY_CONTENT.includes('"continue as guest", 95'),
+    "DISMISS_POSITIVE should include 'continue as guest'");
+  // Turkish coverage — cdpilot's primary audience.
+  assert(PY_CONTENT.includes('"şimdi değil", 80'),
+    "DISMISS_POSITIVE should include Turkish 'şimdi değil'");
+  assert(PY_CONTENT.includes('"üye olmadan", 95'),
+    "DISMISS_POSITIVE should include Turkish 'üye olmadan'");
+});
+
+test('dismiss pattern lib: negatives prevent destructive misfires', () => {
+  // Anti-patterns are load-bearing — they're what makes auto-dismiss safe to
+  // ship as a default-on style helper. If these regress, users lose accounts.
+  assert(/DISMISS_NEGATIVE\s*=/.test(PY_CONTENT),
+    "DISMISS_NEGATIVE list must be declared");
+  assert(PY_CONTENT.includes('"delete account"'),
+    "DISMISS_NEGATIVE must disqualify 'delete account'");
+  assert(PY_CONTENT.includes('"sign out"'),
+    "DISMISS_NEGATIVE must disqualify 'sign out'");
+  assert(PY_CONTENT.includes('"subscribe"'),
+    "DISMISS_NEGATIVE must disqualify 'subscribe'");
+  // Turkish account-destruction patterns
+  assert(PY_CONTENT.includes('"hesabı sil"') || PY_CONTENT.includes('"hesabımı sil"'),
+    "DISMISS_NEGATIVE must disqualify Turkish account-deletion phrasing");
+});
+
+test('cmd_dismiss: one negative hit disqualifies regardless of positives', () => {
+  // Critical invariant: an element matching ANY anti-pattern is out, period.
+  // Without this an element labelled "no thanks, delete account" would still
+  // get a positive score from "no thanks" and be clicked.
+  // Note: the JS lives inside a Python f-string so `{{` in source → `{` after format.
+  const m = PY_CONTENT.match(/checkText[\s\S]{0,800}?NEG\[i\][\s\S]{0,200}?return\s*\{+\s*pos:\s*0,\s*neg:\s*true/);
+  assert(m, "checkText must early-return {pos:0, neg:true} as soon as any NEG pattern hits");
+});
+
+test('cmd_dismiss: visibility gate + min score threshold', () => {
+  // No clicks on invisible elements (0×0 box, display:none, opacity:0). And
+  // weak partial matches must NOT cross the dismiss threshold — that's the
+  // line between "found the escape hatch" and "guessing".
+  assert(/rect\.width === 0 && rect\.height === 0/.test(PY_CONTENT),
+    "Dismiss must skip 0-size elements");
+  assert(/style\.display === 'none' \|\| style\.visibility === 'hidden'/.test(PY_CONTENT),
+    "Dismiss must skip display:none / visibility:hidden");
+  assert(/MIN_SCORE\s*=\s*40/.test(PY_CONTENT),
+    "Dismiss must enforce MIN_SCORE = 40 to avoid weak-match misfires");
+});
+
+test('dismiss registered in dispatch + MCP', () => {
+  assert(/'dismiss':\s*lambda:\s*cmd_dismiss\(/.test(PY_CONTENT),
+    "Should register 'dismiss' in dispatch");
+  assert(PY_CONTENT.includes('"browser_dismiss"'),
+    "Should expose browser_dismiss MCP tool");
+  assert(/"browser_dismiss":\s*lambda\s+a:\s*\["dismiss"\]/.test(PY_CONTENT),
+    "MCP tool_map must route browser_dismiss to the dismiss CLI command");
+});
+
+test('help advertises dismiss command', () => {
+  const out = run('--help');
+  assert(out.includes('dismiss'), "Help should advertise dismiss");
+});
+
 // ── Summary ──
 
 console.log(`\n  ${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
## Summary
New `cdpilot dismiss` command for unauthenticated query workflows against LLM chat sites (ChatGPT, Perplexity, Claude.ai, Gemini) that gate access behind a sign-up modal but offer an escape hatch.

```bash
cdpilot go https://chat.openai.com
cdpilot dismiss              # clicks "Stay signed out" if present
cdpilot dismiss aggressive   # handles chained modal flows
```

## Design

### Two pattern lists, both load-bearing

**`DISMISS_POSITIVE`** (weighted, ordered by intent specificity):
- `"stay signed out"` 100 — direct anonymous-use intent
- `"continue without signing in"` 100
- `"continue as guest"` 95
- `"no thanks"` 85, `"not now"` 80, `"skip"` 65, `"close"` 50, `"later"` 55
- Turkish: `"şimdi değil"` 80, `"üye olmadan"` 95, `"hesapsız devam et"` 95, `"atla"` 65, `"yok teşekkürler"` 85

**`DISMISS_NEGATIVE`** (disqualifier list):
- Account destruction: `"delete account"`, `"hesabı sil"`
- Session destruction: `"sign out"`, `"log out"`, `"çıkış yap"`
- Destructive confirmations: `"yes, delete"`, `"evet, sil"`
- Payment traps: `"subscribe"`, `"upgrade"`, `"satın al"`

**Critical invariant**: one negative hit on ANY of the element's text/aria/title/value attributes and it's disqualified — even if positive patterns also match. Without this, an element labelled "no thanks, delete account" would be a click candidate. The negative list is what makes this safe to ship.

### Other guards
- `MIN_SCORE = 40` threshold — no weak partial matches.
- Visibility gate: skip 0×0, display:none, visibility:hidden, opacity<0.1.
- Exact-text match gets +10 bonus → strongest dismissive button wins.
- Repeat mode (N or `aggressive` up to 5/10) with 400ms pause between scans for chained modals.

### MCP
`browser_dismiss` exposed with optional `repeat` param.

## Test plan
- [x] Unit tests: `node test/test.js` → **65 passed** (6 new locking down the invariants — positive pattern presence, negative pattern presence, negative-first-wins logic, visibility gate, MIN_SCORE threshold, dispatch+MCP wiring).
- [x] Live smoke against a synthetic page with mixed buttons:
  - `Stay signed out` + `Delete account` + `Subscribe` → clicks `Stay signed out` (score 110, exact-match bonus), ignores destructive lookalikes ✓
  - Turkish: `Hesabımı sil` + `Üye ol` + `Şimdi değil` → clicks `Şimdi değil`, ignores account deletion + subscribe ✓
  - Page with ONLY destructive buttons → "No dismiss candidates" (safe) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)