### PR TITLE
chore(release): 0.5.0 — efficient mode, smart navigation, parallel contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to cdpilot will be documented in this file.
 
-## [Unreleased]
+## [0.5.0] - 2026-05-17
+
+> "Run fast in the open lane, climb walls when you see them, then keep running."
+> A release organised around three themes: **quiet professional output**,
+> **wall-aware navigation**, and **true parallelism**.
 
 ### Added
 - **`cdpilot dismiss [N|aggressive]`** — heuristic auto-click for "Stay signed out / No thanks / Continue without account" buttons. Designed for unauthenticated queries against LLM chat sites (ChatGPT, Perplexity, Claude.ai, Gemini) that gate access behind a sign-up modal but offer an escape hatch. Built-in pattern library covers English + Turkish dismissive phrases with weighted scoring (exact-match bonus). **Safety guards** are load-bearing: an explicit negative-pattern list ("delete account", "sign out", "subscribe", Turkish equivalents) disqualifies dangerous lookalikes — one negative hit on any of the element's text/aria/title/value attributes and it's out, regardless of how many positive patterns also match. Visibility gate (0-size, display:none, visibility:hidden, opacity<0.1) and a minimum score threshold of 40 prevent weak-match misfires. Pass an integer N (1-10) or `aggressive` (up to 5) to handle chained modals — common on cookie-banner-then-signup pages. MCP: `browser_dismiss`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,13 +104,22 @@ Brave/Chrome/Chromium (CDP modu, port 9222)
 | ✅ | Auto-Wait | 5s MutationObserver bekleme |
 | ✅ | Batch Commands | JSON pipe desteği |
 | ✅ | Site | cdpilot.ndr.ist canlı (landing + 63 komut docs, browser+health dahil) |
-| ✅ | GitHub & npm | **v0.4.3 yayınlandı**, 6 awesome repo PR'ı |
+| ✅ | GitHub & npm | **v0.5.0 hazırlandı** (lokal); npm publish onay bekliyor |
 | ✅ | Stealth Layer | Zero-dep fingerprint patches (webdriver smart no-op, plugins PluginArray-typed, WebGL spoof, Worker wrap) — opt-in via `cdpilot stealth on` |
 | ✅ | CAPTCHA Detection | 8 sağlayıcı (Turnstile, hCaptcha, reCAPTCHA, DataDome, PerimeterX, Arkose, GeeTest, CF-interstitial). `captcha-check` + `captcha-wait` komutları |
+| ✅ | Adaptive Escalation (v0.5.0) | `cdpilot adaptive on` — CAPTCHA detect → per-host stealth memory + auto re-nav. "Run fast, climb walls when seen" |
+| ✅ | Auto-Dismiss (v0.5.0) | `cdpilot dismiss` — EN+TR pattern lib, destructive-action guards, LLM sign-up wall escape |
+| ✅ | Cookies save/load (v0.5.0) | CF/DataDome clearance replay across runs |
+| ✅ | Context Pool (v0.5.0) | `Target.createBrowserContext` × N + `CDPILOT_TARGET` env pin → true parallel automation |
+| ✅ | Efficient Mode (v0.5.0) | Visual feedback default OFF (`cdpilot show on` opt-in), `cdpilot fast`, scroll instant, post-load 1.5s → 0.3s |
+| ✅ | WS Pool (v0.5.0) | Per-target connection reuse, atexit cleanup, zero tekil-CLI regression |
+| ✅ | `wait-for-text` (v0.5.0) | rAF-throttled MutationObserver — streaming AI response wait |
+| ✅ | `eval-batch` (v0.5.0) | N JS expressions in 1 CDP roundtrip |
+| ✅ | `block` (v0.5.0) | `Network.setBlockedURLs` + image/font/ad presets |
 | ✅ | Browser Selection | `cdpilot browser [name|auto]` — workload-aware (ext var→Vivaldi/Brave, ext yok→Chrome) + macOS 26 Brave demote + per-browser profile izolasyonu |
 | ✅ | Health Probe | `cdpilot health` JSON output — alive, port, tabs, browser, today's crashes. Watchdog loop için exit 0/2 |
 | 🔄 | cdpilot Cloud | Hosted browser sessions API (roadmap) |
-| ⏳ | v0.5.0 | Auto-recovery wrapper (cdp_send fail'de retry + relaunch) |
+| ⏳ | v0.5.0 release | npm publish + site update + sosyal medya duyurusu (onay bekliyor) |
 
 ## Dikkat Edilecekler (Gotchas)
 
@@ -138,7 +147,7 @@ Brave/Chrome/Chromium (CDP modu, port 9222)
 | `cdpilot-video.mp4` | Tam demo videosu (1080x1080, 30fps) |
 
 ---
-Son Güncelleme: 2026-04-21
+Son Güncelleme: 2026-05-17
 
 <!-- gitnexus:start -->
 ## GitNexus — Code Intelligence

--- a/README.md
+++ b/README.md
@@ -86,24 +86,38 @@ npx cdpilot launch    # Start browser with CDP enabled
 npx cdpilot status    # Check connection
 ```
 
-### Upgrading from 0.4.3 → 0.4.4 — read this first
+### Upgrading from 0.4.x → 0.5.0 — read this first
 
-**Visual feedback default flipped to OFF.** The green glow border, animated
-fake cursor, click ripples, and keystroke display made cdpilot feel like an
-amateur typing on every page. They are now opt-in:
+**One breaking change**, the rest is additive.
+
+**Breaking — Visual feedback default flipped to OFF.** The green glow border,
+animated fake cursor, click ripples, and keystroke display made cdpilot feel
+like an amateur typing on every page. They are now opt-in:
 
 ```bash
 cdpilot show on     # restore the old visual feedback layer
-cdpilot show off    # default since 0.4.4
+cdpilot show off    # default since 0.5.0
 ```
 
 The MCP server's persistent-glow flow (`CDPILOT_MCP_SESSION=1`) is **unchanged**
 — AI agents that rely on visible feedback during a session still see it
 automatically. Only direct-CLI users see the difference.
 
-Other 0.4.4 changes are pure performance and require no migration:
-post-load sleep cut 1500ms → 300ms, `scrollIntoView('smooth')` →
-`'instant'` everywhere, new `cdpilot fast` toggle for shorter auto-waits.
+**New in 0.5.0** (no migration needed):
+
+- `cdpilot dismiss` — heuristic auto-click for "Stay signed out / No thanks"
+  buttons on LLM chat sign-up walls.
+- `cdpilot adaptive on` — auto-escalate to stealth on CAPTCHA-protected
+  hosts, with persistent per-host memory.
+- `cdpilot cookies save/load` — export/import cookies as JSON to replay
+  CF/DataDome clearance across runs.
+- `cdpilot context create/list/close` + `CDPILOT_TARGET` — isolated browser
+  contexts for true parallel automation inside a single browser.
+- `cdpilot fast` / `cdpilot show` — bundled timing + visual toggles.
+- Pure performance: post-load sleep 1500ms → 300ms, `scrollIntoView` instant,
+  WebSocket connection pool, `/json` TTL cache.
+
+See [CHANGELOG.md](CHANGELOG.md) for the full list with rationale.
 
 ## Commands
 
@@ -250,7 +264,10 @@ cdpilot session-close [id]    # Close session
 ### Advanced
 
 ```bash
-cdpilot cookies [domain]      # List cookies
+cdpilot cookies [domain]      # List cookies (filter by domain)
+cdpilot cookies save <file> [<domain>]
+                              # Export cookies as JSON (optional domain filter)
+cdpilot cookies load <file>   # Import cookies (replay CF clearance across runs)
 cdpilot storage               # localStorage contents
 cdpilot upload <sel> <file>   # Upload file to input
 cdpilot multi-eval <js>       # Execute JS in all tabs
@@ -259,6 +276,36 @@ cdpilot frame list            # List iframes
 cdpilot dialog auto-accept    # Auto-accept dialogs
 cdpilot permission grant geo  # Grant geolocation
 ```
+
+### Parallel Contexts
+
+```bash
+cdpilot context create [url]  # Make fresh browser context + tab (prints JSON)
+cdpilot context list          # Tree of contexts and their tabs
+cdpilot context close <ctx>   # Destroy a context (refuses 'default')
+```
+
+Address a specific context's tab in subsequent commands via the env pin:
+
+```bash
+ID=$(cdpilot context create https://example.com | jq -r .target_id)
+CDPILOT_TARGET=$ID cdpilot eval 'document.title'
+```
+
+> True isolation — each context has its own cookie/storage jar. Designed for
+> running N AI chat queries in parallel without history pollution, or A/B
+> testing logged-in vs logged-out flows without spinning up multiple browsers.
+
+### Smart Navigation (LLM-aware)
+
+```bash
+cdpilot dismiss               # Click best "Stay signed out / No thanks" button
+cdpilot dismiss aggressive    # Handle chained modals (cookie banner → signup)
+```
+
+> Built-in English + Turkish pattern library. Explicitly excludes destructive
+> lookalikes (Delete account, Sign out, Subscribe) — safe to chain into a
+> query workflow.
 
 ### Stealth & CAPTCHA
 
@@ -277,7 +324,19 @@ cdpilot captcha-check         # JSON detection of Turnstile/hCaptcha/reCAPTCHA/
                               # DataDome/PerimeterX/Arkose/GeeTest. Exit 0/3
 cdpilot captcha-wait [sec]    # block until user solves (interactive)
                               # or poll with JSON stream (non-interactive)
+
+cdpilot adaptive [on|off|status]
+                              # Auto-escalate to stealth on hosts that show
+                              # CAPTCHA. Persistent per-host memory.
+cdpilot adaptive forget <host>
+                              # Remove a hostname from the stealth list
+cdpilot adaptive clear        # Drop the stealth host memory entirely
 ```
+
+> **Adaptive mode** is the "run fast, climb walls when seen" automation: cdpilot
+> runs in the open lane by default, detects CAPTCHA after each navigation, and
+> when it sees one — adds the host to a persistent list, retries once with
+> stealth on. Never auto-demotes. Conservative by design.
 
 Verified against public bot-detection panels:
 - **bot.sannysoft.com:** 24/24 PASS (WebDriver, Chrome obj, Plugins as PluginArray, WebGL, PHANTOM_*, HEADCHR_*, SELENIUM_DRIVER)
@@ -411,6 +470,12 @@ The only browser MCP with built-in test assertions. Here's what we've shipped an
 - [x] **`wait-for-text`** — adaptive text-based waiting (subtree + characterData) for streaming AI responses, async toasts, and selector-less synchronization
 - [x] **`eval-batch`** — run N JS expressions in 1 CDP roundtrip (5-30x speedup vs sequential `eval`)
 - [x] **`block`** — request blocking via `Network.setBlockedURLs` with built-in presets (images/fonts/ads/media), 3-10x faster page loads on opt-in
+- [x] **`dismiss`** — heuristic auto-click for LLM chat sign-up walls (EN+TR pattern library, destructive-action guards)
+- [x] **`adaptive`** — auto-escalate to stealth on CAPTCHA-protected hosts, persistent per-host memory ("run fast, climb walls")
+- [x] **`cookies save/load`** — export/import cookies as JSON (replay CF/DataDome clearance across runs)
+- [x] **`context` pool + `CDPILOT_TARGET`** — isolated browser contexts for true parallel automation in a single browser (Playwright's parallel-tabs model)
+- [x] **`fast` / `show`** — bundled timing + visual toggles. Default quiet/fast in 0.5.0
+- [x] **WebSocket pool + `/json` TTL cache** — zero-regression connection reuse for MCP/batch workloads
 - [x] **Batch commands** — pipe JSON arrays via stdin for multi-step automation
 - [x] Visual feedback system (persistent green glow, cursor, ripples, keystroke display)
 - [x] AI control warning toast (red warning when user interacts during automation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdpilot",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Zero-dependency browser automation from your terminal. One command, full control.",
   "bin": {
     "cdpilot": "./bin/cdpilot.js",

--- a/src/cdpilot.py
+++ b/src/cdpilot.py
@@ -14,7 +14,7 @@ Environment:
   CDPILOT_PROFILE      Isolated browser profile directory
 """
 
-__version__ = "0.4.4"
+__version__ = "0.5.0"
 
 import asyncio
 import atexit

--- a/test/test.js
+++ b/test/test.js
@@ -40,12 +40,12 @@ console.log('\n  cdpilot tests\n');
 
 test('--version prints version', () => {
   const out = run('--version');
-  assert(out.includes('0.4.4'), 'Should print version');
+  assert(out.includes('0.5.0'), 'Should print version');
 });
 
 test('-v prints version', () => {
   const out = run('-v');
-  assert(out.includes('0.4.4'), 'Should print version');
+  assert(out.includes('0.5.0'), 'Should print version');
 });
 
 test('help shows usage', () => {


### PR DESCRIPTION
## Summary
Release docs + version bump 0.4.4 → 0.5.0. Six PRs since 0.4.4 (#16–#21) ship as one coordinated release organised around three themes.

## Themes

### 1. Quiet professional output
- Visual feedback default **OFF** (`cdpilot show on` to restore)
- `scrollIntoView` smooth → instant everywhere
- Post-load sleep **1500ms → 300ms**
- `cdpilot fast`: bundled timing knobs (auto-wait 5s → 2s)

### 2. Wall-aware navigation
- `cdpilot dismiss`: heuristic auto-click for LLM sign-up walls (EN + TR pattern lib, destructive-action guards)
- `cdpilot adaptive`: per-host stealth memory + auto re-nav on CAPTCHA
- `cdpilot cookies save/load`: replay CF clearance across runs

### 3. True parallelism
- `cdpilot context create/list/close`: `Target.createBrowserContext` isolation. Address tabs via `CDPILOT_TARGET` env pin from concurrent CLI processes — Playwright's parallel-tabs model in a zero-dep CLI.
- WebSocket connection pool for `cdp_send` (regression-free, opt-out via `CDPILOT_WS_POOL=0`)
- `/json` TTL cache (auto-invalidates on tab mutation)

### Bonus additive primitives
- `wait-for-text`: streaming-aware MutationObserver (rAF-throttled)
- `eval-batch`: N JS expressions in 1 `Runtime.evaluate` roundtrip
- `block`: `Network.setBlockedURLs` + image/font/ad presets

## Breaking changes
**Exactly one**: visual feedback default flip. Migration in README "Upgrading from 0.4.x → 0.5.0". The MCP persistent-glow flow (`CDPILOT_MCP_SESSION=1`) is unchanged — no migration needed for that path.

## This PR
- `package.json` + `src/cdpilot.py`: version → 0.5.0
- `CHANGELOG.md`: `[Unreleased]` dated `[0.5.0] 2026-05-17` with theme intro
- `README.md`: Upgrade section refreshed, new **Parallel Contexts** and **Smart Navigation** sections, Stealth & CAPTCHA expanded with adaptive, Cookies entries expanded with save/load, Shipped list +4 entries
- `CLAUDE.md` (project memory): Aktif Çalışma table refreshed with all v0.5.0 features
- `test/test.js`: version assertion 0.4.4 → 0.5.0

## Next steps (not in this PR — need user approval)
- [ ] `npm publish` (release to npm registry)
- [ ] Update `cdpilot-site` repo (cdpilot.ndr.ist) with new commands
- [ ] Social announcement (HN / Twitter)

## Test plan
- [x] `node test/test.js` → **83 passed** (no regressions from version bump)
- [x] `cdpilot --version` reports `0.5.0` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)